### PR TITLE
Check that build-dir is not empty to consider resuse

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -84,7 +84,7 @@ class Builder:
 
     def download_pigen(self):
         """clone requested version of Pi-gen"""
-        if self.conf.build_dir.exists():
+        if self.conf.build_dir.exists() and list(self.conf.build_dir.iterdir()):
             logger.warning(f"build-dir exists. reusing ({self.conf.build_dir}")
             return
         logger.info("Cloning Pi-gen")


### PR DESCRIPTION
Builder assumes that if the build-dir is present, it is on purpose and should not
clone pi-gen inside.
We were only testing for the existence of the folder which would be true when the
build-dir is not specified as it is inited to a tempdir.

We are now checking whether there are files inside as well.

Fixes #10 