### PR TITLE
Build and publish workflow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,0 +1,65 @@
+name: Build & Upload
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Set BASE_IMAGE_FILENAME_RADICAL from branch name
+        if: startsWith(github.ref, 'refs/tags/') != true
+        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-$GITHUB_HEAD_REF-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set BASE_IMAGE_FILENAME_RADICAL from tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set BASE_IMAGE_FILENAME
+        run: echo "BASE_IMAGE_FILENAME=${{ env.BASE_IMAGE_FILENAME_RADICAL }}.img.xz" >> $GITHUB_ENV
+
+      - name: Set BASE_IMAGE_INFO_FILENAME
+        run: echo "BASE_IMAGE_INFO_FILENAME=${{ env.BASE_IMAGE_FILENAME_RADICAL }}.info" >> $GITHUB_ENV
+
+      - name: Build base image
+        run: |
+          sudo modprobe binfmt_misc
+          sudo apt install qemu-user-static
+          ./builder.py --compress --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
+
+      - name: Upload base image to S3
+        if: startsWith(github.ref, 'refs/tags/') != true
+        env:
+          S3URL: ${{ secrets.BRANCHES_S3_URL }}
+        run: |
+          pip3 install "kiwixstorage==0.8.3" "progressbar2==4.0.0" "humanfriendly==10.0"
+          echo "Uploading image ${{ env.BASE_IMAGE_FILENAME }} & info to S3..."
+          s3upload "${{ env.BASE_IMAGE_FILENAME }}"
+          s3upload "${{ env.BASE_IMAGE_INFO_FILENAME }}"
+          echo '### Artefacts' >> $GITHUB_STEP_SUMMARY
+          echo '- [${{ env.BASE_IMAGE_FILENAME }}](https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/${{ env.BASE_IMAGE_FILENAME }})' >> $GITHUB_STEP_SUMMARY
+          echo '- [${{ env.BASE_IMAGE_INFO_FILENAME }}](https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/${{ env.BASE_IMAGE_INFO_FILENAME }})' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload base image to WebDAV
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "Uploading image ${{ env.BASE_IMAGE_FILENAME }} & info to WebDAV..."
+          curl -u "${{ secrets.DRIVE_CREDENTIALS }}" -T "${{ env.BASE_IMAGE_FILENAME }}" -sw '%{http_code}' "https://drive.offspot.it/_webdav/base/${{ env.BASE_IMAGE_FILENAME }}"
+          curl -u "${{ secrets.DRIVE_CREDENTIALS }}" -T "${{ env.BASE_IMAGE_INFO_FILENAME }}" -sw '%{http_code}' "https://drive.offspot.it/_webdav/base/${{ env.BASE_IMAGE_INFO_FILENAME }}"
+          echo '### Artefacts' >> $GITHUB_STEP_SUMMARY
+          echo '- [${{ env.BASE_IMAGE_FILENAME }}](https://drive.offspot.it/base/${{ env.BASE_IMAGE_FILENAME }})' >> $GITHUB_STEP_SUMMARY
+          echo '- [${{ env.BASE_IMAGE_INFO_FILENAME }}](https://drive.offspot.it/base/${{ env.BASE_IMAGE_INFO_FILENAME }})' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,6 @@
 name: QA
 
-on: [push, pull_request]
+on: push
 
 env:
   # black default

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A Raspberry-targetting image to use as *master* for both Kiwix Offspot and OLIP through the use of [`image-creator`](https://github.com/offspot/image-creator).
 
+[![release](https://img.shields.io/github/v/tag/offspot/base-image?label=latest%20release&sort=semver)](https://drive.offspot.it/base/)
 [![CodeFactor](https://www.codefactor.io/repository/github/offspot/base-image/badge)](https://www.codefactor.io/repository/github/offspot/base-image)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 


### PR DESCRIPTION
Fixes #8

New `build-and-upload`:
* Build the image `img.xz`
* Publish the `img.xz` and corresponding `.info` to S3 in case of feature branch and to https://drive.offspot.it/base in case of release tag on git `master`