### PR TITLE
Added support for --output param

### DIFF
--- a/tree/stage2/EXPORT_IMAGE
+++ b/tree/stage2/EXPORT_IMAGE
@@ -1,0 +1,1 @@
+IMG_SUFFIX=""


### PR DESCRIPTION
Added `--output` param which takes a filename (cwd) or full path to store the built
image at. Image is built inside pigen folder and moved there upon completion (Fixes #15)

pi-gen is instructed not to compress image so default output is uncompressed.
A `--compress` option compresses the built image into xz, removing the uncompressed version (Fixes #16)

.info file is also moved next to requested image output, with .info extension (Fixes #17)