### PR TITLE
Add exfat data partition

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   build:
+    env:
+      # developers's public keys to facilitate testing (only for test builds)
+      PUBKEYS: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4UTXOYXrKA6dR7KizO2AvqqHKQGJE/FZF2oKTiofWEYDf+UWylksH4WjFmVczDUHN653Ve/QOIyRfI6IUuVa2hJ+l02xFV7rdl7L5zSZwKiSJr+SefouzWIFwS3VS3gbLOqk864a1NkUR97yKYjxsZiT9fISf771HqEKhsXOzZDOFbxt5u+YAaAJIJlU0EMKkDRBBtAVxmLFHme0uSpZ8DlYMFARGe1s0I++1eby0NVtzP3TarouvkPN1cFmS7UhQCsHzcmDMcNyrtHGBnlgjihd4m2bppmY75xTTR/PQTKDWqwklyYZhiDCKjZYzxWTk493SwKfZfaT9FOU0r4FT reg@kiwix|ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAEAQCgGhWboby8xdQzJUQdq67mo2RmmFB54y5qjji9BhIa36dAr/K2OMEIgQVsyAuF8/8fc5ezbbZkgln4azBTWDSmHjgQ8h/B3A7lZ9U29FymiATy/7YAb5o62AIzDrZS775QPEBOKry/gZRbBDbxLk372Q/J2FUIrcdTNQq8MVU9AmFX75E79oXX/dIxV5LHegBEVyLzWmf2yATRfBdBlL1WkgYQKItkTO+ClPsCUYMyKy03jea9KWUcW/7rYbicRFHwxCE4nZ/oCaB6ROEV7/o32MSmge6Yc35tBCIY6UBEeiYoxK0mOfca1/CJ3yWZhI/4XyPLZtOgl3FybOnyVfnLvhE7UaPhnVo/oSqjwIzLkVcu4P4fxpplxwCTMhXa9qHNwCJQzhr77wWzIG7kIyAqSY9Lx1YosqKoN7hLKCHjf06aY+agGvQ0iugWf0re5jUXFhhcja3PNpxwTpHap1QeKlXNiPgiSTGgZNSiJ9qyDmHOxrtOHZXlaXx0anrSKCRD/3XqQAkk0n8KbKS6Ik5ur3D3htHtSo7zwr7XprFqLYK07CzxviiVKNR9O5ATHSpiF9UZJnCbRllBLzelGyzz2qRMwJR+R8O7dGPPDUV5Tb8YmSA42TFLBduLZ7U+mtbUa2diApxMxO3S6d2QPiZGc3jUmI0dAkm6h3c3Sbi2kdFDhHe2bo58yu7NTF1TN0Of2dUZySGuM7nNdfmceJYKfgDxtIW7XwKbsin9uwrR3jRJp7HNRpc+InXEU9w61EcZFD9d+ou9hwHtby4g9DnKhlFTz6MyfbMc686qOCL6LbU659aszwf0LlgDcN+wXCHyZ/1fyPAMiHEMZJ6D6NbqprUJ1yYvh/69fRuSdEk21b8bkxFnGKPZVBalxRL+zq7LP5ONSnbibHAO9Qh7848cOz4Kq5SaVMfypmeh2Rz9kB5Y3by9/jZIuoOm2FwIXOO1fC1rh9Wlk8Z30MdV9//8heFD9JVLIcR+Irb/fMVb5ejcyrs82rH2E4NN4yrnpSzlLnDgF/+IdzzUurXYJqtfkh1Ngb7/32lOBwrXv8elqvZHxzM3iNrHNS5VpLz89zG8xlbQTiuTPJZePKmljaqeo4qI5PUGh3XbBUR6KDsdJHdJZB1Z8Tyt1WwuNOtPtpgb9vquRCYXZLe2rwm5GMannDcl+sgDzI8d+DaARgMdtaffdy9IczNozpuVtAzDxKTmR5qd2EgYQqU29FbTRdyC3avYGVajgwgsDykvWZppKOfusnvKMRNN9hPSwnHXwKO97dtvjJVogtbbKT54c/CeTY538QF9Xd/oFVHdy7QvG0uFmxQ2leFRxmIUmgmW+IlWGR7HpmI9leFt9T133eaj tom@bsf|ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpp290SxTzG0+cz1LJBKwVogAj30kGqGcgRZ+z1rAYJH8QydA8ruFhVjpAgClkMiVoDBJIHOSGyTE2qD74PV2JmXq9gOuMHvQxjwFUpmC4V9WCO9omJM8lO/2rlo6PCYppUH450ppypUGYL1mNY1z4ZP4DbPIDU+QVABG+5vkQsmBKc2Pr/ZX4pzqISGwJSiFunFnsoXs7nk/qHN5tf7fh5md8kQBsS2+wygDdQyALLHIMlUCayyQL8kulEPxs+cJxkbImyG4wHKAgKi8Ei3z6tHL8Lr7w1hVUDmlDBE5TkKHeHtwV1Ai0VGmTiM18NyFIlkmZNkp4mFJtWVbnqPI+Q2GXnMa388CHVJUfpWIdSs5O1i8bP32h33azx0z849azjyox9xugJlCh0l6C3bVCOJn1TcZ9i9vCrGG3P4dbtz9hQtPthl/p+970wMm1p5AXtb6RBDdeFmTM511i4Mgdepg1dC0xEgzVTpLKrwsR2LPICl4/ClNAGZqcHtMBScm2+3imfHuTJk4GY06XQ6UnhZTSJqUS8FGxwCPz9B2ppd+2rNWrtfpdRuphVBGUbwBevJpK/S/SgjWFiF8YKba0Jn/FBjgXDWJsN8tJirUsvDQrM9KWXcOwcD0jvNdvYBLxIDHlCY3noQ80+2PZTT6by5GOGE1CaczVGn4Yktm/nQ== florian@bsf|"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -44,7 +47,15 @@ jobs:
       - name: Set BASE_IMAGE_INFO_FILENAME
         run: echo "BASE_IMAGE_INFO_FILENAME=${{ env.BASE_IMAGE_FILENAME_RADICAL }}.info" >> $GITHUB_ENV
 
-      - name: Build base image
+      - name: Build test base image
+        if: startsWith(github.ref, 'refs/tags/') != true
+        run: |
+          sudo modprobe binfmt_misc
+          sudo apt install qemu-user-static
+          ./builder.py --arch "${{ matrix.arch }}" --compress --enable-ssh 1 --pubkey-ssh-first-user "${PUBKEYS//|/\\n}" --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
+
+      - name: Build prod base image
+        if: startsWith(github.ref, 'refs/tags/') == true
         run: |
           sudo modprobe binfmt_misc
           sudo apt install qemu-user-static

--- a/packages
+++ b/packages
@@ -5,3 +5,6 @@
 + git
 + vim
 + screen
+
+# exfat support (mkfs, fsck)
++ exfatprogs

--- a/tree/Dockerfile.patch
+++ b/tree/Dockerfile.patch
@@ -1,0 +1,11 @@
+--- pigen/Dockerfile	2022-05-24 16:22:49.000000000 +0000
++++ tree/Dockerfile	2022-05-25 11:39:32.000000000 +0000
+@@ -5,7 +5,7 @@
+ 
+ RUN apt-get -y update && \
+     apt-get -y install --no-install-recommends \
+-        git vim parted \
++        git vim parted exfatprogs exfat-fuse lsb-release \
+         quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
+         libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
+         binfmt-support ca-certificates qemu-utils kpartx fdisk gpg pigz\

--- a/tree/export-image/01-user-rename/01-run.sh.patch
+++ b/tree/export-image/01-user-rename/01-run.sh.patch
@@ -1,0 +1,9 @@
+--- tree.orig/export-image/01-user-rename/01-run.sh	2022-05-31 10:21:03.000000000 +0000
++++ tree/export-image/01-user-rename/01-run.sh	2022-07-08 15:58:12.000000000 +0000
+@@ -1,5 +1,3 @@
+ #!/bin/bash -e
+ 
+-on_chroot << EOF
+-	SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
+-EOF
++

--- a/tree/export-image/04-set-partuuid/00-run.sh
+++ b/tree/export-image/04-set-partuuid/00-run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
+
+	IMG_FILE="${STAGE_WORK_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.img"
+
+	IMGID="$(dd if="${IMG_FILE}" skip=440 bs=1 count=4 2>/dev/null | xxd -e | cut -f 2 -d' ')"
+
+	BOOT_PARTUUID="${IMGID}-01"
+	ROOT_PARTUUID="${IMGID}-02"
+	DATA_PARTUUID="${IMGID}-03"
+
+	sed -i "s/BOOTDEV/PARTUUID=${BOOT_PARTUUID}/" "${ROOTFS_DIR}/etc/fstab"
+	sed -i "s/ROOTDEV/PARTUUID=${ROOT_PARTUUID}/" "${ROOTFS_DIR}/etc/fstab"
+	sed -i "s/DATADEV/PARTUUID=${DATA_PARTUUID}/" "${ROOTFS_DIR}/etc/fstab"
+
+	sed -i "s/ROOTDEV/PARTUUID=${ROOT_PARTUUID}/" "${ROOTFS_DIR}/boot/cmdline.txt"
+
+fi
+

--- a/tree/export-image/prerun.sh
+++ b/tree/export-image/prerun.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -e
+
+if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
+    IMG_FILE="${STAGE_WORK_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.img"
+
+    unmount_image "${IMG_FILE}"
+
+    rm -f "${IMG_FILE}"
+
+    rm -rf "${ROOTFS_DIR}"
+    mkdir -p "${ROOTFS_DIR}"
+
+    BOOT_SIZE="$((256 * 1024 * 1024))"
+    ROOT_SIZE=$(du --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --exclude boot --block-size=1 | cut -f 1)
+    # use ~256Mi for data. shall be recreated by final-image creator tool
+    DATA_SIZE="$((256 * 1024 * 1024))"
+
+    # All partition sizes and starts will be aligned to this size
+    ALIGN="$((4 * 1024 * 1024))"
+    # Add this much space to the calculated file size. This allows for
+    # some overhead (since actual space usage is usually rounded up to the
+    # filesystem block size) and gives some free space on the resulting
+    # image.
+    ROOT_MARGIN="$(echo "($ROOT_SIZE * 0.2 + 384 * 1024 * 1024) / 1" | bc)"
+    # disbale data margin as it will eventually be recreated to fit device size
+    DATA_MARGIN="0"
+
+    BOOT_PART_START=$((ALIGN))
+    BOOT_PART_SIZE=$(((BOOT_SIZE + ALIGN - 1) / ALIGN * ALIGN))
+    ROOT_PART_START=$((BOOT_PART_START + BOOT_PART_SIZE))
+    ROOT_PART_SIZE=$(((ROOT_SIZE + ROOT_MARGIN + ALIGN  - 1) / ALIGN * ALIGN))
+    IMG_SIZE=$((BOOT_PART_START + BOOT_PART_SIZE + ROOT_PART_SIZE))
+    # include data part into IMG_SIZE calculation
+    DATA_PART_START=$((ROOT_PART_START + ROOT_PART_SIZE))
+    DATA_PART_SIZE=$(((DATA_SIZE + DATA_MARGIN + ALIGN  - 1) / ALIGN * ALIGN))
+    IMG_SIZE=$((BOOT_PART_START + BOOT_PART_SIZE + ROOT_PART_SIZE + DATA_PART_SIZE))
+
+    truncate -s "${IMG_SIZE}" "${IMG_FILE}"
+
+    parted --script "${IMG_FILE}" mklabel msdos
+    parted --script "${IMG_FILE}" unit B mkpart primary fat32 "${BOOT_PART_START}" "$((BOOT_PART_START + BOOT_PART_SIZE - 1))"
+    parted --script "${IMG_FILE}" unit B mkpart primary ext4 "${ROOT_PART_START}" "$((ROOT_PART_START + ROOT_PART_SIZE - 1))"
+    parted --script "${IMG_FILE}" unit B mkpart primary NTFS "${DATA_PART_START}" "$((DATA_PART_START + DATA_PART_SIZE - 1))"
+
+    PARTED_OUT=$(parted -sm "${IMG_FILE}" unit b print)
+    BOOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 2 | tr -d B)
+    BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
+
+    ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
+    ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
+
+    DATA_OFFSET=$(echo "$PARTED_OUT" | grep -e '^3:' | cut -d':' -f 2 | tr -d B)
+    DATA_LENGTH=$(echo "$PARTED_OUT" | grep -e '^3:' | cut -d':' -f 4 | tr -d B)
+
+    echo "Mounting BOOT_DEV..."
+    cnt=0
+    until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+        if [ $cnt -lt 5 ]; then
+            cnt=$((cnt + 1))
+            echo "Error in losetup for BOOT_DEV.  Retrying..."
+            sleep 5
+        else
+            echo "ERROR: losetup for BOOT_DEV failed; exiting"
+            exit 1
+        fi
+    done
+
+    echo "Mounting ROOT_DEV..."
+    cnt=0
+    until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+        if [ $cnt -lt 5 ]; then
+            cnt=$((cnt + 1))
+            echo "Error in losetup for ROOT_DEV.  Retrying..."
+            sleep 5
+        else
+            echo "ERROR: losetup for ROOT_DEV failed; exiting"
+            exit 1
+        fi
+    done
+
+    echo "Mounting DATA_DEV..."
+    cnt=0
+    until DATA_DEV=$(losetup --show -f -o "${DATA_OFFSET}" --sizelimit "${DATA_LENGTH}" "${IMG_FILE}"); do
+        if [ $cnt -lt 5 ]; then
+            cnt=$((cnt + 1))
+            echo "Error in losetup for DATA_DEV.  Retrying..."
+            sleep 5
+        else
+            echo "ERROR: losetup for DATA_DEV failed; exiting"
+            exit 1
+        fi
+    done
+
+    echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
+    echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
+    echo "/data:     offset $DATA_OFFSET, length $DATA_LENGTH"
+
+    ROOT_FEATURES="^huge_file"
+    for FEATURE in metadata_csum 64bit; do
+    if grep -q "$FEATURE" /etc/mke2fs.conf; then
+        ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"
+    fi
+    done
+    mkdosfs -n boot -F 32 -v "$BOOT_DEV" > /dev/null
+    mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$ROOT_DEV" > /dev/null
+    mkfs.exfat -L data "$DATA_DEV" > /dev/null
+
+    mount -v "$ROOT_DEV" "${ROOTFS_DIR}" -t ext4
+    mkdir -p "${ROOTFS_DIR}/boot"
+    mount -v "$BOOT_DEV" "${ROOTFS_DIR}/boot" -t vfat
+    mkdir -p "${ROOTFS_DIR}/data"
+    
+    mount.exfat-fuse "$DATA_DEV" "${ROOTFS_DIR}/data"
+    touch "${ROOTFS_DIR}/data/master_fs"
+
+    # create docker filesystem
+    mkdir -p ${ROOTFS_DIR}/data/docker
+    dd if=/dev/zero of=${ROOTFS_DIR}/data/docker.fs bs=DOCKER_FS_SIZE count=1
+    mkfs.ext4 -L docker ${ROOTFS_DIR}/data/docker.fs
+
+    rsync -aHAXx --exclude /var/cache/apt/archives --exclude /boot "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/"
+    rsync -rtx "${EXPORT_ROOTFS_DIR}/boot/" "${ROOTFS_DIR}/boot/"
+fi

--- a/tree/stage1/01-sys-tweaks/files/fstab.patch
+++ b/tree/stage1/01-sys-tweaks/files/fstab.patch
@@ -1,0 +1,8 @@
+--- tree.orig/stage1/01-sys-tweaks/files/fstab	2022-05-31 10:21:03.000000000 +0000
++++ tree/stage1/01-sys-tweaks/files/fstab	2022-07-08 14:02:54.000000000 +0000
+@@ -1,3 +1,5 @@
+ proc            /proc           proc    defaults          0       0
+ BOOTDEV  /boot           vfat    defaults,flush    0       2
+ ROOTDEV  /               ext4    defaults,noatime  0       1
++DATADEV  /data           exfat   umask=0002,uid=1000,gid=33,x-systemd.device-timeout=3min  0       0
++/data/docker.fs /data/docker    ext4    defaults,noatime,x-systemd.requires=/data       0       0

--- a/tree/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
+++ b/tree/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
@@ -1,0 +1,5 @@
+--- stage2.orig/rootfs/boot/cmdline.txt
++++ stage2/rootfs/boot/cmdline.txt
+@@ -1 +1 @@
+-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait
++console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait quiet init=/usr/sbin/offspot_bi_init_resize.sh

--- a/tree/stage2/01-sys-tweaks/01-run.sh.patch
+++ b/tree/stage2/01-sys-tweaks/01-run.sh.patch
@@ -1,22 +1,11 @@
---- tree.orig/stage2/01-sys-tweaks/01-run.sh    2022-05-31 10:21:03.000000000 +0000
-+++ tree/stage2/01-sys-tweaks/01-run.sh 2022-07-08 17:14:48.000000000 +0000
-@@ -11,6 +11,9 @@
-
- install -m 755 files/rc.local      "${ROOTFS_DIR}/etc/"
-
-+install -m 644 files/offspot.conf  "${ROOTFS_DIR}/etc/modules-load.d/"
-+install -m 755 files/offspot_bi_init_resize.sh "${ROOTFS_DIR}/usr/sbin/"
-+
+--- tree.orig/stage2/01-sys-tweaks/01-run.sh	2022-05-31 10:21:03.000000000 +0000
++++ tree/stage2/01-sys-tweaks/01-run.sh	2022-07-22 15:50:34.000000000 +0000
+@@ -13,7 +13,7 @@
+ 
  if [ -n "${PUBKEY_SSH_FIRST_USER}" ]; then
-    install -v -m 0700 -o 1000 -g 1000 -d "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh
-    echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
-@@ -47,6 +50,9 @@
- systemctl enable resize2fs_once
- EOF
+ 	install -v -m 0700 -o 1000 -g 1000 -d "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh
+-	echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
++	echo -e "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
+ 	chown 1000:1000 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
+ 	chmod 0600 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
  fi
-+on_chroot << EOF
-+systemctl enable resize2fs_once
-+EOF
-
- on_chroot <<EOF
- for GRP in input spi i2c gpio; do

--- a/tree/stage2/01-sys-tweaks/01-run.sh.patch
+++ b/tree/stage2/01-sys-tweaks/01-run.sh.patch
@@ -1,0 +1,22 @@
+--- tree.orig/stage2/01-sys-tweaks/01-run.sh    2022-05-31 10:21:03.000000000 +0000
++++ tree/stage2/01-sys-tweaks/01-run.sh 2022-07-08 17:14:48.000000000 +0000
+@@ -11,6 +11,9 @@
+
+ install -m 755 files/rc.local      "${ROOTFS_DIR}/etc/"
+
++install -m 644 files/offspot.conf  "${ROOTFS_DIR}/etc/modules-load.d/"
++install -m 755 files/offspot_bi_init_resize.sh "${ROOTFS_DIR}/usr/sbin/"
++
+ if [ -n "${PUBKEY_SSH_FIRST_USER}" ]; then
+    install -v -m 0700 -o 1000 -g 1000 -d "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh
+    echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
+@@ -47,6 +50,9 @@
+ systemctl enable resize2fs_once
+ EOF
+ fi
++on_chroot << EOF
++systemctl enable resize2fs_once
++EOF
+
+ on_chroot <<EOF
+ for GRP in input spi i2c gpio; do

--- a/tree/stage2/01-sys-tweaks/01-run.sh.patch
+++ b/tree/stage2/01-sys-tweaks/01-run.sh.patch
@@ -1,7 +1,12 @@
 --- tree.orig/stage2/01-sys-tweaks/01-run.sh	2022-05-31 10:21:03.000000000 +0000
-+++ tree/stage2/01-sys-tweaks/01-run.sh	2022-07-22 15:50:34.000000000 +0000
-@@ -13,7 +13,7 @@
++++ tree/stage2/01-sys-tweaks/01-run.sh	2022-07-25 13:40:42.000000000 +0000
+@@ -11,9 +11,12 @@
  
+ install -m 755 files/rc.local		"${ROOTFS_DIR}/etc/"
+ 
++install -m 644 files/offspot.conf  "${ROOTFS_DIR}/etc/modules-load.d/"
++install -m 755 files/offspot_bi_init_resize.sh "${ROOTFS_DIR}/usr/sbin/"
++
  if [ -n "${PUBKEY_SSH_FIRST_USER}" ]; then
  	install -v -m 0700 -o 1000 -g 1000 -d "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh
 -	echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
@@ -9,3 +14,13 @@
  	chown 1000:1000 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
  	chmod 0600 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
  fi
+@@ -47,6 +50,9 @@
+ systemctl enable resize2fs_once
+ EOF
+ fi
++on_chroot << EOF
++systemctl enable resize2fs_once
++EOF
+ 
+ on_chroot <<EOF
+ for GRP in input spi i2c gpio; do

--- a/tree/stage2/01-sys-tweaks/files/offspot.conf
+++ b/tree/stage2/01-sys-tweaks/files/offspot.conf
@@ -1,0 +1,2 @@
+# offspot's list of modules to load at boot
+exfat

--- a/tree/stage2/01-sys-tweaks/files/offspot_bi_init_resize.sh
+++ b/tree/stage2/01-sys-tweaks/files/offspot_bi_init_resize.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+
+# adaptation of raspi-config's init_resize.sh script that is used
+# as an init on first on-device boot to resize root partition to fill sd size.
+#
+# this version does not resize root partition (its size is fixed) but takes care of
+# our third “data” partition.
+# this partition being exfat, it can't be resized and is recreated, passing its
+# content to root partition (in /tmp) temporarily so it's not lost.
+#
+# /!\ there should not be any substantial data on /data partition at this stage
+# this “backup” feature is complimentary.
+# Any tool using this base image should recreate the /data partition to its wanted
+# size and thus remove the /data/master_fs flag file that enables this to run.
+#
+# https://github.com/RPi-Distro/raspi-config/blob/master/usr/lib/raspi-config/init_resize.sh
+
+reboot_pi () {
+  umount /boot
+  umount /data
+  mount / -o remount,ro
+  sync
+  reboot -f
+  sleep 5
+  exit 0
+}
+
+check_commands () {
+  if ! command -v whiptail > /dev/null; then
+      echo "whiptail not found"
+      sleep 5
+      return 1
+  fi
+  for COMMAND in grep cut sed parted fdisk findmnt; do
+    if ! command -v $COMMAND > /dev/null; then
+      FAIL_REASON="$COMMAND not found"
+      return 1
+    fi
+  done
+  return 0
+}
+
+get_variables () {
+	ROOT_PART_DEV=$(findmnt / -o source -n)
+	ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
+	ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+	ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+	ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
+
+	BOOT_PART_DEV=$(findmnt /boot -o source -n)
+	BOOT_PART_NAME=$(echo "$BOOT_PART_DEV" | cut -d "/" -f 3)
+	BOOT_DEV_NAME=$(echo /sys/block/*/"${BOOT_PART_NAME}" | cut -d "/" -f 4)
+	BOOT_PART_NUM=$(cat "/sys/block/${BOOT_DEV_NAME}/${BOOT_PART_NAME}/partition")
+
+	DATA_PART_DEV=$(findmnt /data -o source -n)
+	DATA_PART_NAME=$(echo "$DATA_PART_DEV" | cut -d "/" -f 3)
+	DATA_DEV_NAME=$(echo /sys/block/*/"${DATA_PART_NAME}" | cut -d "/" -f 4)
+	DATA_DEV="/dev/${DATA_DEV_NAME}"
+	DATA_PART_NUM=$(cat "/sys/block/${DATA_DEV_NAME}/${DATA_PART_NAME}/partition")
+
+	OLD_DISKID=$(fdisk -l "$ROOT_DEV" | sed -n 's/Disk identifier: 0x\([^ ]*\)/\1/p')
+
+	ROOT_DEV_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/size")
+	TARGET_END=$((ROOT_DEV_SIZE - 1))
+
+	PARTITION_TABLE=$(parted -m "$ROOT_DEV" unit s print | tr -d 's')
+
+	LAST_PART_NUM=$(echo "$PARTITION_TABLE" | tail -n 1 | cut -d ":" -f 1)
+
+	ROOT_PART_LINE=$(echo "$PARTITION_TABLE" | grep -e "^${ROOT_PART_NUM}:")
+	ROOT_PART_START=$(echo "$ROOT_PART_LINE" | cut -d ":" -f 2)
+	ROOT_PART_END=$(echo "$ROOT_PART_LINE" | cut -d ":" -f 3)
+
+	DATA_PART_LINE=$(echo "$PARTITION_TABLE" | grep -e "^${DATA_PART_NUM}:")
+	DATA_PART_START=$(echo "$DATA_PART_LINE" | cut -d ":" -f 2)
+	DATA_PART_END=$(echo "$DATA_PART_LINE" | cut -d ":" -f 3)
+}
+
+fix_partuuid() {
+  mount -o remount,rw "$ROOT_PART_DEV"
+  mount -o remount,rw "$BOOT_PART_DEV"
+  DISKID="$(tr -dc 'a-f0-9' < /dev/hwrng | dd bs=1 count=8 2>/dev/null)"
+  if printf "x\ni\n0x$DISKID\nr\nw\n" | fdisk "$ROOT_DEV" > /dev/null; then
+    sed -i "s/${OLD_DISKID}/${DISKID}/g" /etc/fstab
+    sed -i "s/${OLD_DISKID}/${DISKID}/" /boot/cmdline.txt
+    sync
+  fi
+
+  mount -o remount,ro "$ROOT_PART_DEV"
+  mount -o remount,ro "$BOOT_PART_DEV"
+}
+
+check_variables () {
+
+  if [ "$BOOT_DEV_NAME" != "$ROOT_DEV_NAME" ] || [ "$ROOT_DEV_NAME" != "$DATA_DEV_NAME" ]; then
+      FAIL_REASON="Boot, root and data partitions are not all on same device"
+      return 1
+  fi
+
+  if [ "$DATA_PART_NUM" -ne "$LAST_PART_NUM" ]; then
+    FAIL_REASON="Data partition should be last partition"
+    return 1
+  fi
+
+  if [ "$DATA_PART_END" -gt "$TARGET_END" ]; then
+    FAIL_REASON="Data partition runs past the end of device"
+    return 1
+  fi
+
+  if [ ! -b "$ROOT_DEV" ] || [ ! -b "$ROOT_PART_DEV" ] || [ ! -b "$DATA_PART_DEV" ] || [ ! -b "$BOOT_PART_DEV" ] ; then
+    FAIL_REASON="Could not determine partitions"
+    return 1
+  fi
+}
+
+main () {
+  get_variables
+
+  if ! check_variables; then
+    return 1
+  fi
+
+  if [ "$DATA_PART_END" -eq "$TARGET_END" ]; then
+    reboot_pi
+  fi
+
+  # dump /data content (should not be large) into /tmp
+  mount / -o remount,rw
+  mount /data -o remount,ro
+  tar -c -f /mnt/data_part.tar --exclude "/data/master_fs" /data
+  sync
+  umount /data
+
+  # resize partition (not filesystem)
+  if ! parted -m "$ROOT_DEV" u s resizepart "$DATA_PART_NUM" "$TARGET_END"; then
+    FAIL_REASON="Data partition resize failed"
+    return 1
+  fi
+
+  # recreate filesystem (can't rezise exFAT)
+  mkfs.exfat -L data "$DATA_PART_DEV" > /dev/null
+
+  # restore files onto data partition
+  mount /data -o rw
+  tar -C /data -x --strip-components 1 -f /mnt/data_part.tar
+  rm -f /mnt/data_part.tar
+  sync
+  mount / -o remount,ro
+  mount /data -o remount,ro
+
+  fix_partuuid
+
+  return 0
+}
+
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mount -t tmpfs tmp /run
+mkdir -p /run/systemd
+
+mount /boot
+mount / -o remount,ro
+mount /data -o ro
+
+sed -i 's| init=/usr/sbin/offspot_bi_init_resize\.sh||' /boot/cmdline.txt
+sed -i 's| sdhci\.debug_quirks2=4||' /boot/cmdline.txt
+
+if ! grep -q splash /boot/cmdline.txt; then
+  sed -i "s/ quiet//g" /boot/cmdline.txt
+fi
+sync
+mount /boot -o remount,ro
+
+if ! check_commands; then
+  reboot_pi
+fi
+
+if main; then
+  whiptail --infobox "Recreated data filesystem. Rebooting in 5 seconds..." 20 60
+  sleep 5
+else
+  whiptail --msgbox "Could not recreate data filesystem Rebooting...\n${FAIL_REASON}" 20 60
+  sleep 5
+fi
+
+reboot_pi

--- a/tree/stage2/01-sys-tweaks/files/offspot_bi_init_resize.sh
+++ b/tree/stage2/01-sys-tweaks/files/offspot_bi_init_resize.sh
@@ -162,6 +162,7 @@ mount /boot
 mount / -o remount,ro
 mount /data -o ro
 
+# remove itself from boot, regardless of whether we're resizing or not
 sed -i 's| init=/usr/sbin/offspot_bi_init_resize\.sh||' /boot/cmdline.txt
 sed -i 's| sdhci\.debug_quirks2=4||' /boot/cmdline.txt
 
@@ -170,6 +171,11 @@ if ! grep -q splash /boot/cmdline.txt; then
 fi
 sync
 mount /boot -o remount,ro
+
+# skip resizing process if not on a declared master fs
+if [ ! -f /data/master_fs ] ; then
+    reboot_pi
+fi
 
 if ! check_commands; then
   reboot_pi


### PR DESCRIPTION
export-image's prerun.sh has been rewritten to add an additional partition that is formatted to exfat.
It is mounted at `/data` and contains a `master_fs` flag file.

rootfs margin is set to 384Mi so it has a small space to use should it be needed ; since it won't be resized anymore.

A new `docker.fs` file is created on the third partition. It holds an empty ext4 filesytem that we'll be able to use for docker storage. Its size is configurable and default to 100MB. That docker fs is mounted at `/data/docker`

During build, exfat support is provided by exfat-fuse (only installed on build-system, not on target) and mkfs.exfat is provided (and installed) by exfatprogs (new exfat-related tools built by samsung and mounts via fuse). `exfat` module is loaded on start so we don't rely on fuse after build.

Similarily to how raspbian works, a first-time init script *resizes* the data partition. It actually recreates it as it can't be resized. This behavior is meant for base-image only as we expect base-image using creators to create full-size images.

**Note**: I've also included removal of the new *rename-user* behavior that's super annoying for tests and that we don't need (renaming of default user upon first start)