### PR TITLE
some host-maint tools

### DIFF
--- a/packages
+++ b/packages
@@ -3,8 +3,10 @@
 # comment and empty lines are omitted ; lines and package names are stripped
 + bash-completion
 + git
-+ vim
-+ screen
++ iftop
++ iotop
++ tmux
++ locate
 
 # exfat support (mkfs, fsck)
 + exfatprogs

--- a/packages
+++ b/packages
@@ -7,6 +7,9 @@
 + iotop
 + tmux
 + locate
++ ncurses-term
++ jq
++ tree
 
 # exfat support (mkfs, fsck)
 + exfatprogs

--- a/tree/stage2/01-sys-tweaks/01-run.sh.patch
+++ b/tree/stage2/01-sys-tweaks/01-run.sh.patch
@@ -16,12 +16,16 @@
  	chown 1000:1000 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
  	chmod 0600 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
  fi
-@@ -47,6 +52,9 @@
+@@ -47,6 +52,13 @@
  systemctl enable resize2fs_once
  EOF
  fi
 +on_chroot << EOF
 +systemctl enable resize2fs_once
++EOF
++
++on_chroot << EOF
++ln -s /usr/bin/vim.tiny /usr/local/bin/vim
 +EOF
  
  on_chroot <<EOF


### PR DESCRIPTION
A few useful (and lightweight!) tools for maintenance. `screen` replaced by `tmux`.
`vim` removed as `vim.tiny` is already included (as well as `htop` and `ncdu`

Fixes #21