### PR TITLE
runtime-config dependencies & deployment

### DIFF
--- a/packages
+++ b/packages
@@ -16,3 +16,9 @@
 
 # using docker instead of balena or podman
 + docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# runtime-config
++ python3-pip python3-yaml
+
+# AP stack
++ hostapd dnsmasq

--- a/tree/stage2/01-sys-tweaks/01-run.sh.patch
+++ b/tree/stage2/01-sys-tweaks/01-run.sh.patch
@@ -4,7 +4,7 @@
  
  install -m 755 files/rc.local		"${ROOTFS_DIR}/etc/"
  
-+install -m 755 files/offspot.json  "${ROOTFS_DIR}/boot/"
++install -m 755 files/offspot.yaml  "${ROOTFS_DIR}/boot/"
 +
 +install -m 644 files/offspot.conf  "${ROOTFS_DIR}/etc/modules-load.d/"
 +install -m 755 files/offspot_bi_init_resize.sh "${ROOTFS_DIR}/usr/sbin/"

--- a/tree/stage2/01-sys-tweaks/files/offspot.json
+++ b/tree/stage2/01-sys-tweaks/files/offspot.json
@@ -1,3 +1,0 @@
-{
-  "hostname": "offspot-base"
-}

--- a/tree/stage2/01-sys-tweaks/files/offspot.yaml
+++ b/tree/stage2/01-sys-tweaks/files/offspot.yaml
@@ -1,0 +1,9 @@
+# base image version
+---
+timezone: UTC
+hostname: base-image
+ethernet:
+  type: dhcp
+ap:
+  ssid: Offspot base-image
+  as-gateway: true

--- a/tree/stage2/02-net-tweaks/01-run.sh.patch
+++ b/tree/stage2/02-net-tweaks/01-run.sh.patch
@@ -1,0 +1,24 @@
+--- tree.orig/stage2/02-net-tweaks/01-run.sh	2022-05-31 10:21:03.000000000 +0000
++++ tree/stage2/02-net-tweaks/01-run.sh	2022-09-14 15:55:11.000000000 +0000
+@@ -35,3 +35,21 @@
+     echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
+     echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
+ fi
++
++# unblock WiFi
++echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
++echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
++
++# runtime config firewall persistence (ap)
++mkdir -p ${ROOTFS_DIR}/etc/iptables
++install -m 755 files/iptables-restore.service       "${ROOTFS_DIR}/etc/systemd/system/"
++
++install -m 664 files/dhcpcd.conf       "${ROOTFS_DIR}/etc/"
++
++on_chroot << EOF
++systemctl daemon-reload
++systemctl enable dhcpcd.service
++systemctl unmask hostapd
++systemctl disable hostapd.service dnsmasq.service iptables-restore.service
++EOF
++

--- a/tree/stage2/02-net-tweaks/files/dhcpcd.conf
+++ b/tree/stage2/02-net-tweaks/files/dhcpcd.conf
@@ -1,0 +1,64 @@
+# A sample configuration for dhcpcd.
+# See dhcpcd.conf(5) for details.
+
+# Allow users of this group to interact with dhcpcd via the control socket.
+#controlgroup wheel
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# Most distributions have NTP support.
+#option ntp_servers
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate SLAAC address using the Hardware Address of the interface
+#slaac hwaddr
+# OR generate Stable Private IPv6 Addresses based from the DUID
+slaac private
+
+# prevent dhcpcd from fiddling with wlan0
+denyinterfaces wlan0
+nohook wpa_supplicant
+
+# fallback static
+profile static_eth0
+static ip_address=192.168.1.2/24
+static routers=192.168.1.1
+static domain_name_servers=192.168.1.1
+
+# static configuration
+interface eth0
+noipv6
+ipv4only
+noalias
+
+### config-network: start ###
+dhcp
+### config-network: stop ###
+
+# fallback to static profile on eth0
+fallback static_eth0

--- a/tree/stage2/02-net-tweaks/files/iptables-restore.service
+++ b/tree/stage2/02-net-tweaks/files/iptables-restore.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Restore iptables configuration
+After=offspot-runtime.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/find /etc/iptables/ -name '*.rules' -exec /sbin/iptables-restore {} \;
+
+[Install]
+WantedBy=multi-user.target

--- a/tree/stage2/06-docker-tweaks/files/compose.yml
+++ b/tree/stage2/06-docker-tweaks/files/compose.yml
@@ -10,6 +10,6 @@ services:
       - "80:80"
     volumes:
       - type: bind
-        source: /boot/offspot.json
-        target: /var/www/offspot.json
+        source: /boot/offspot.yaml
+        target: /var/www/offspot.yaml
         read_only: true

--- a/tree/stage2/06-docker-tweaks/files/docker-compose.service
+++ b/tree/stage2/06-docker-tweaks/files/docker-compose.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker compose service
 BindsTo=docker.service
-After=docker-images-loader.service
+After=docker-images-loader.service offspot-runtime.service iptables-restore.service
 
 [Service]
 ExecStart=/usr/bin/docker compose -f /etc/docker/compose.yml up --remove-orphans

--- a/tree/stage2/07-sys-configurator/01-run.sh
+++ b/tree/stage2/07-sys-configurator/01-run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+on_chroot << EOF
+pip3 install offspot-runtime-config==1.0.0
+EOF
+
+install -m 755 files/offspot-runtime.service       "${ROOTFS_DIR}/etc/systemd/system/"
+
+on_chroot << EOF
+systemctl daemon-reload
+systemctl enable offspot-runtime.service
+EOF

--- a/tree/stage2/07-sys-configurator/files/offspot-runtime.service
+++ b/tree/stage2/07-sys-configurator/files/offspot-runtime.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Offspot Runtime
+Requires=network.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/offspot-config-fromfile /boot/offspot.yaml
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=docker-compose.service multi-user.target
+RequiredBy=docker-compose.service


### PR DESCRIPTION
Installs `offspot-runtime-config` (launched via an `offspot-runtime` systemd unit) with all its dependencies and configurations:
- `/boot/offspot.json` replaced by `/boot/offspot.yaml`

Note that `offspot.yaml` does not sets `containers`. We already have a *default* compose file.

Systemd units are very important as there are important dependencies/order between services:
- `iptables-restores` must happen **after** `offspot-runtime`, as runtime-config cannot disable rules (only remove from persistence)
- `docker-compose` must be ran last, so after `offspot-runtime`, which might have changed the compose file and `docker-images-loader` (obviously)

We request systemd **NOT to launch** `hostapd` and `dnsmasq`. `offspot-runtime` launches them manually. We also start offspot-runtime **after** network-online.target as we need all interfaces.

## Notes

- Test it by launching the image ; an open AP should be there, sharing its eth0 connection (if any)
- You can change `/boot/offspot.yaml` and restart to confirm it does what's expected (see runtime-config README)
- ⚠️ We are installing `offspot-config-runtime` from the git branch of the other repo, until https://github.com/offspot/runtime-config/pull/1 is merged and we make a release.