### PR TITLE
Fixes for 2022-09-06 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Based on 2022-04-04-raspios-bullseye's pi-gen
+* Based on 2022-09-06-raspios-bullseye's pi-gen

--- a/tree/export-image/01-user-rename/01-run.sh.patch-armhf
+++ b/tree/export-image/01-user-rename/01-run.sh.patch-armhf
@@ -1,9 +1,0 @@
---- tree.orig/export-image/01-user-rename/01-run.sh	2022-05-31 10:21:03.000000000 +0000
-+++ tree/export-image/01-user-rename/01-run.sh	2022-07-08 15:58:12.000000000 +0000
-@@ -1,5 +1,3 @@
- #!/bin/bash -e
- 
--on_chroot << EOF
--	SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
--EOF
-+

--- a/tree/export-image/prerun.sh
+++ b/tree/export-image/prerun.sh
@@ -96,6 +96,7 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
     echo "/data:     offset $DATA_OFFSET, length $DATA_LENGTH"
 
     ROOT_FEATURES="^huge_file"
+    # shellcheck disable=SC2043
     for FEATURE in 64bit; do
     if grep -q "$FEATURE" /etc/mke2fs.conf; then
         ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"

--- a/tree/export-image/prerun.sh
+++ b/tree/export-image/prerun.sh
@@ -96,12 +96,12 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
     echo "/data:     offset $DATA_OFFSET, length $DATA_LENGTH"
 
     ROOT_FEATURES="^huge_file"
-    for FEATURE in metadata_csum 64bit; do
+    for FEATURE in 64bit; do
     if grep -q "$FEATURE" /etc/mke2fs.conf; then
         ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"
     fi
     done
-    mkdosfs -n boot -F 32 -v "$BOOT_DEV" > /dev/null
+    mkdosfs -n boot -F 32 -s 4 -v "$BOOT_DEV" > /dev/null
     mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$ROOT_DEV" > /dev/null
     mkfs.exfat -L data "$DATA_DEV" > /dev/null
 

--- a/tree/stage1/01-sys-tweaks/files/fstab.patch
+++ b/tree/stage1/01-sys-tweaks/files/fstab.patch
@@ -2,7 +2,7 @@
 +++ tree/stage1/01-sys-tweaks/files/fstab	2022-07-08 14:02:54.000000000 +0000
 @@ -1,3 +1,5 @@
  proc            /proc           proc    defaults          0       0
- BOOTDEV  /boot           vfat    defaults,flush    0       2
+ BOOTDEV  /boot           vfat    defaults    0       2
  ROOTDEV  /               ext4    defaults,noatime  0       1
 +DATADEV  /data           exfat   umask=0002,uid=1000,gid=33,x-systemd.device-timeout=3min  0       0
 +/data/virtual.fs /data/virtual    ext4    defaults,noatime,x-systemd.requires=/data       0       0


### PR DESCRIPTION
Slight (but required) modifications for the new september raspiOS release.

Main change is in the builder script to use a specific version of the `arm64` branch which is not tagged on pigen.