### PR TITLE
Reduce disk writes

### DIFF
--- a/tree/stage1/01-sys-tweaks/files/fstab.patch
+++ b/tree/stage1/01-sys-tweaks/files/fstab.patch
@@ -1,8 +1,13 @@
 --- tree.orig/stage1/01-sys-tweaks/files/fstab	2022-05-31 10:21:03.000000000 +0000
 +++ tree/stage1/01-sys-tweaks/files/fstab	2022-07-08 14:02:54.000000000 +0000
-@@ -1,3 +1,5 @@
+@@ -1,3 +1,10 @@
  proc            /proc           proc    defaults          0       0
  BOOTDEV  /boot           vfat    defaults    0       2
  ROOTDEV  /               ext4    defaults,noatime  0       1
 +DATADEV  /data           exfat   umask=0002,uid=1000,gid=33,x-systemd.device-timeout=3min  0       0
 +/data/virtual.fs /data/virtual    ext4    defaults,noatime,x-systemd.requires=/data       0       0
++tmpfs            /tmp            tmpfs            nosuid,nodev            0            0
++tmpfs            /var/log            tmpfs            nosuid,nodev            0            0
++tmpfs            /var/tmp            tmpfs            nosuid,nodev            0            0
++tmpfs            /var/lib/misc            tmpfs            nosuid,nodev            0            0
++tmpfs            /var/cache            tmpfs            nosuid,nodev            0            0

--- a/tree/stage2/06-docker-tweaks/01-run.sh
+++ b/tree/stage2/06-docker-tweaks/01-run.sh
@@ -2,7 +2,7 @@
 
 # instruct docker to work off the loop-device and use a low-disk-space-usage logger
 mkdir -p ${ROOTFS_DIR}/etc/docker
-printf '{"data-root": "/data/virtual/docker", "log-driver": "local", "log-opts": {"max-size": "5m", "max-file": "2"}}' > ${ROOTFS_DIR}/etc/docker/daemon.json
+printf '{"data-root": "/data/virtual/docker", "log-driver": "journald"}' > ${ROOTFS_DIR}/etc/docker/daemon.json
 
 # instruct containerd to work off the loop-device as well
 sed -i -E 's/^#root\s=.+/root = "\/data\/virtual\/containerd"/' ${ROOTFS_DIR}/etc/containerd/config.toml

--- a/tree/stage2/08-log-tweaks/00-patches/01-rsyslog.diff
+++ b/tree/stage2/08-log-tweaks/00-patches/01-rsyslog.diff
@@ -1,0 +1,14 @@
+Index: jessie-stage2/rootfs/etc/rsyslog.conf
+===================================================================
+--- jessie-stage2.orig/rootfs/etc/rsyslog.conf
++++ jessie-stage2/rootfs/etc/rsyslog.conf
+@@ -55,6 +55,9 @@
+ #### RULES ####
+ ###############
+
++# offspot disable syslog
++*.*         ~
++
+ #
+ # First some standard log files.  Log by facility.
+ #

--- a/tree/stage2/08-log-tweaks/00-patches/series
+++ b/tree/stage2/08-log-tweaks/00-patches/series
@@ -1,0 +1,1 @@
+01-rsyslog.diff

--- a/tree/stage2/08-log-tweaks/01-run.sh
+++ b/tree/stage2/08-log-tweaks/01-run.sh
@@ -1,0 +1,8 @@
+
+# journald drop-in to set journal to volatile
+mkdir -p ${ROOTFS_DIR}/etc/systemd/journald.conf.d
+install -m 644 files/00-offspot-volatile.conf		"${ROOTFS_DIR}/etc/systemd/journald.conf.d/"
+
+# custom motd with log setup details
+install -m 644 files/motd		"${ROOTFS_DIR}/etc/"
+install -m 644 files/offspot-logs		"${ROOTFS_DIR}/etc/"

--- a/tree/stage2/08-log-tweaks/files/00-offspot-volatile.conf
+++ b/tree/stage2/08-log-tweaks/files/00-offspot-volatile.conf
@@ -1,0 +1,5 @@
+[Journal]
+# journal files to be stored in /run/log/journal
+Storage=volatile
+# max file size for journal
+RuntimeMaxUse=30M

--- a/tree/stage2/08-log-tweaks/files/motd
+++ b/tree/stage2/08-log-tweaks/files/motd
@@ -1,0 +1,5 @@
++-+-+-+-+-+-+-+
+|o|f|f|s|p|o|t|
++-+-+-+-+-+-+-+
+
+syslog is disabled, journald is volatile. Read more in /etc/offspot-logs

--- a/tree/stage2/08-log-tweaks/files/offspot-logs
+++ b/tree/stage2/08-log-tweaks/files/offspot-logs
@@ -1,0 +1,15 @@
+In a regular Offspot config:
+
+All messages to syslog are discarded.
+This can be changed in /etc/rsyslog.conf by commenting-out the `*.* ~` line.
+This requires restarting the service: `systemctl restart rsyslog`
+
+Additionnaly, systemd's journald is volatile: not persisting logs accross reboots.
+It also sets a limit to the journal size.
+This can be disabled in /etc/systemd/journald.conf.d/00-offspot-volatile.conf
+This requires restarting the service: `systemctl restart systemd-journald`
+
+Additionnaly, /var/log is mounted as tmpfs.
+This can be changed by commenting-out according line in /etc/fstab.
+This requires remounting: `mount -o remount /var/log`.
+If files are busy in /var/log, stop related services before remounting (or just restart)


### PR DESCRIPTION
Fixes #20

Reducing disk writes mostly through logs management:

## disabling docker's own log store

We're instructing docker to send logs to journald so it's not storing files for it but `docker logs` can still be used.
Logs are also visible using `journalctl`

## disabling syslog

most of the logs should be going through systemd but regular syslog can still happen.
We are disabling the storage of syslog logs (so it's not affecting apps) by sending
all of them to the void.

## contain journald

main log store being systemd's journald, we are instructing it to use volatile storage.
Instead of storing on file in `/var/log/journal`, it stores it on RAM in `/run/log/journal`.
We are also requesting at most `30M` of journal storage.

Decided not to sync logs to disk (as does log2ram) as I don't think we'll ever need those
logs so it saves writes and complexity. Should one need the logs, it's still possible to
tweak the settings back.

## mouting write-intensive candidates to RAM

Mounting the following as tmpfs:

- `/tmp`, `/var/tmp`
- `/var/cache`
- `/var/lib/misc`
- `/var/log`

Should prevent apps from writing logs to disk, from writting temp files to disk.

Decided not to set size limits on those mounts as this sounds difficult, fragile and error-prone.

## informing admin

As those are unexpected configurations on a system and because of the (hopefuly) rare
debug interventions, the motd has been changed and a logs-setup details file is added
so that admin knows where to find stuff and how to change setup should he need to.



# Testing

- login (console or ssh): motd is displayed
- `/etc/offspot-logs` exists
- `ls -l /var/log/` doesn't lists syslog files (auth.log, messages, etc)
- `mount |grep tmpfs` lists /tmp, /var/log, etc
- `systemctl status docker-compose` should show running service
- `docker logs base-httpd` shows logs
- `journalctl -b CONTAINER_NAME=base-httpd` shows same log