### PR TITLE
Better manual run names

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,4 +1,5 @@
 name: Build & Upload
+run-name: ${{ github.event.head_commit.message || 'Manual Build & Upload' }} - ${{ github.ref_type }}/${{ github.ref_name }}
 
 on:
   push:


### PR DESCRIPTION
Here's an improvement over the current situation although it's not ideal because we only have one expression with limited context to use.

**Current situation for pushes and pull requests**
<img width="955" alt="pr" src="https://user-images.githubusercontent.com/57929/192992637-33709561-909b-4076-b7b9-79aaa3f57675.png">

this one was correct, showing the commit message and proper metadata like branch.

**Current**
<img width="965" alt="previous" src="https://user-images.githubusercontent.com/57929/192992745-69f49295-37dd-49e9-adbe-2a24583769df.png">

This is what happens on manual runs: only the workflow name, no metadata.

**With this PR**
<img width="956" alt="new" src="https://user-images.githubusercontent.com/57929/192992849-e0f1c9f5-9817-4ea4-9f0a-caf60ac52c3c.png">

We'll now have a clear mention of it being a manual run and the branch (in the name, not in metadata)


Fixes #33 