### PR TITLE
64b first

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -21,14 +21,11 @@ jobs:
       # developers's public keys to facilitate testing (only for test builds)
       PUBKEYS: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4UTXOYXrKA6dR7KizO2AvqqHKQGJE/FZF2oKTiofWEYDf+UWylksH4WjFmVczDUHN653Ve/QOIyRfI6IUuVa2hJ+l02xFV7rdl7L5zSZwKiSJr+SefouzWIFwS3VS3gbLOqk864a1NkUR97yKYjxsZiT9fISf771HqEKhsXOzZDOFbxt5u+YAaAJIJlU0EMKkDRBBtAVxmLFHme0uSpZ8DlYMFARGe1s0I++1eby0NVtzP3TarouvkPN1cFmS7UhQCsHzcmDMcNyrtHGBnlgjihd4m2bppmY75xTTR/PQTKDWqwklyYZhiDCKjZYzxWTk493SwKfZfaT9FOU0r4FT reg@kiwix|ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAEAQCgGhWboby8xdQzJUQdq67mo2RmmFB54y5qjji9BhIa36dAr/K2OMEIgQVsyAuF8/8fc5ezbbZkgln4azBTWDSmHjgQ8h/B3A7lZ9U29FymiATy/7YAb5o62AIzDrZS775QPEBOKry/gZRbBDbxLk372Q/J2FUIrcdTNQq8MVU9AmFX75E79oXX/dIxV5LHegBEVyLzWmf2yATRfBdBlL1WkgYQKItkTO+ClPsCUYMyKy03jea9KWUcW/7rYbicRFHwxCE4nZ/oCaB6ROEV7/o32MSmge6Yc35tBCIY6UBEeiYoxK0mOfca1/CJ3yWZhI/4XyPLZtOgl3FybOnyVfnLvhE7UaPhnVo/oSqjwIzLkVcu4P4fxpplxwCTMhXa9qHNwCJQzhr77wWzIG7kIyAqSY9Lx1YosqKoN7hLKCHjf06aY+agGvQ0iugWf0re5jUXFhhcja3PNpxwTpHap1QeKlXNiPgiSTGgZNSiJ9qyDmHOxrtOHZXlaXx0anrSKCRD/3XqQAkk0n8KbKS6Ik5ur3D3htHtSo7zwr7XprFqLYK07CzxviiVKNR9O5ATHSpiF9UZJnCbRllBLzelGyzz2qRMwJR+R8O7dGPPDUV5Tb8YmSA42TFLBduLZ7U+mtbUa2diApxMxO3S6d2QPiZGc3jUmI0dAkm6h3c3Sbi2kdFDhHe2bo58yu7NTF1TN0Of2dUZySGuM7nNdfmceJYKfgDxtIW7XwKbsin9uwrR3jRJp7HNRpc+InXEU9w61EcZFD9d+ou9hwHtby4g9DnKhlFTz6MyfbMc686qOCL6LbU659aszwf0LlgDcN+wXCHyZ/1fyPAMiHEMZJ6D6NbqprUJ1yYvh/69fRuSdEk21b8bkxFnGKPZVBalxRL+zq7LP5ONSnbibHAO9Qh7848cOz4Kq5SaVMfypmeh2Rz9kB5Y3by9/jZIuoOm2FwIXOO1fC1rh9Wlk8Z30MdV9//8heFD9JVLIcR+Irb/fMVb5ejcyrs82rH2E4NN4yrnpSzlLnDgF/+IdzzUurXYJqtfkh1Ngb7/32lOBwrXv8elqvZHxzM3iNrHNS5VpLz89zG8xlbQTiuTPJZePKmljaqeo4qI5PUGh3XbBUR6KDsdJHdJZB1Z8Tyt1WwuNOtPtpgb9vquRCYXZLe2rwm5GMannDcl+sgDzI8d+DaARgMdtaffdy9IczNozpuVtAzDxKTmR5qd2EgYQqU29FbTRdyC3avYGVajgwgsDykvWZppKOfusnvKMRNN9hPSwnHXwKO97dtvjJVogtbbKT54c/CeTY538QF9Xd/oFVHdy7QvG0uFmxQ2leFRxmIUmgmW+IlWGR7HpmI9leFt9T133eaj tom@bsf|ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpp290SxTzG0+cz1LJBKwVogAj30kGqGcgRZ+z1rAYJH8QydA8ruFhVjpAgClkMiVoDBJIHOSGyTE2qD74PV2JmXq9gOuMHvQxjwFUpmC4V9WCO9omJM8lO/2rlo6PCYppUH450ppypUGYL1mNY1z4ZP4DbPIDU+QVABG+5vkQsmBKc2Pr/ZX4pzqISGwJSiFunFnsoXs7nk/qHN5tf7fh5md8kQBsS2+wygDdQyALLHIMlUCayyQL8kulEPxs+cJxkbImyG4wHKAgKi8Ei3z6tHL8Lr7w1hVUDmlDBE5TkKHeHtwV1Ai0VGmTiM18NyFIlkmZNkp4mFJtWVbnqPI+Q2GXnMa388CHVJUfpWIdSs5O1i8bP32h33azx0z849azjyox9xugJlCh0l6C3bVCOJn1TcZ9i9vCrGG3P4dbtz9hQtPthl/p+970wMm1p5AXtb6RBDdeFmTM511i4Mgdepg1dC0xEgzVTpLKrwsR2LPICl4/ClNAGZqcHtMBScm2+3imfHuTJk4GY06XQ6UnhZTSJqUS8FGxwCPz9B2ppd+2rNWrtfpdRuphVBGUbwBevJpK/S/SgjWFiF8YKba0Jn/FBjgXDWJsN8tJirUsvDQrM9KWXcOwcD0jvNdvYBLxIDHlCY3noQ80+2PZTT6by5GOGE1CaczVGn4Yktm/nQ== florian@bsf|"
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        arch: [arm64, armhf]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.1.0
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Setup Python 3.8
         uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.8
@@ -36,11 +33,11 @@ jobs:
 
       - name: Set BASE_IMAGE_FILENAME_RADICAL from branch name
         if: startsWith(github.ref, 'refs/tags/') != true
-        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-${{ matrix.arch }}-$GITHUB_HEAD_REF-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-arm64-$GITHUB_HEAD_REF-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Set BASE_IMAGE_FILENAME_RADICAL from tag name
         if: startsWith(github.ref, 'refs/tags/')
-        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-${{ matrix.arch }}-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "BASE_IMAGE_FILENAME_RADICAL=offspot-base-arm64-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Set BASE_IMAGE_FILENAME
         run: echo "BASE_IMAGE_FILENAME=${{ env.BASE_IMAGE_FILENAME_RADICAL }}.img.xz" >> $GITHUB_ENV
@@ -54,7 +51,7 @@ jobs:
           sudo modprobe binfmt_misc
           sudo apt update
           sudo apt install qemu-user-static
-          ./builder.py --arch "${{ matrix.arch }}" --compress --enable-ssh 1 --pubkey-ssh-first-user "${PUBKEYS//|/\\n}" --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
+          ./builder.py --compress --enable-ssh 1 --pubkey-ssh-first-user "${PUBKEYS//|/\\n}" --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
 
       - name: Build prod base image
         if: startsWith(github.ref, 'refs/tags/') == true
@@ -62,10 +59,10 @@ jobs:
           sudo modprobe binfmt_misc
           sudo apt update
           sudo apt install qemu-user-static
-          ./builder.py --arch "${{ matrix.arch }}" --compress --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
+          ./builder.py --compress --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
 
       - name: Upload base image to S3
-        if: github.event.inputs.publish-to-s3 == 'yes' && matrix.arch == 'arm64'
+        if: github.event.inputs.publish-to-s3 == 'yes'
         env:
           S3URL: ${{ secrets.BRANCHES_S3_URL }}
         run: |
@@ -78,9 +75,9 @@ jobs:
           echo '- [${{ env.BASE_IMAGE_INFO_FILENAME }}](https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/${{ env.BASE_IMAGE_INFO_FILENAME }})' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload base image to WebDAV
-        if: startsWith(github.ref, 'refs/tags/') && matrix.arch == 'arm64'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "Uploading ${{ matrix.arch }} image ${{ env.BASE_IMAGE_FILENAME }} & info to WebDAV..."
+          echo "Uploading image ${{ env.BASE_IMAGE_FILENAME }} & info to WebDAV..."
           curl -u "${{ secrets.DRIVE_CREDENTIALS }}" -T "${{ env.BASE_IMAGE_FILENAME }}" -sw '%{http_code}' "https://drive.offspot.it/_webdav/base/${{ env.BASE_IMAGE_FILENAME }}"
           curl -u "${{ secrets.DRIVE_CREDENTIALS }}" -T "${{ env.BASE_IMAGE_INFO_FILENAME }}" -sw '%{http_code}' "https://drive.offspot.it/_webdav/base/${{ env.BASE_IMAGE_INFO_FILENAME }}"
           echo "### Artefacts" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -52,6 +52,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') != true
         run: |
           sudo modprobe binfmt_misc
+          sudo apt update
           sudo apt install qemu-user-static
           ./builder.py --arch "${{ matrix.arch }}" --compress --enable-ssh 1 --pubkey-ssh-first-user "${PUBKEYS//|/\\n}" --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
 
@@ -59,6 +60,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') == true
         run: |
           sudo modprobe binfmt_misc
+          sudo apt update
           sudo apt install qemu-user-static
           ./builder.py --arch "${{ matrix.arch }}" --compress --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armhf, arm64]
+        arch: [arm64, armhf]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.8
           architecture: x64
@@ -63,7 +63,7 @@ jobs:
           ./builder.py --arch "${{ matrix.arch }}" --compress --output "${{ env.BASE_IMAGE_FILENAME_RADICAL }}"
 
       - name: Upload base image to S3
-        if: ${{ github.event.inputs.publish-to-s3 == 'yes' }}
+        if: github.event.inputs.publish-to-s3 == 'yes' && matrix.arch == 'arm64'
         env:
           S3URL: ${{ secrets.BRANCHES_S3_URL }}
         run: |
@@ -76,7 +76,7 @@ jobs:
           echo '- [${{ env.BASE_IMAGE_INFO_FILENAME }}](https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/${{ env.BASE_IMAGE_INFO_FILENAME }})' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload base image to WebDAV
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.arch == 'arm64'
         run: |
           echo "Uploading ${{ matrix.arch }} image ${{ env.BASE_IMAGE_FILENAME }} & info to WebDAV..."
           curl -u "${{ secrets.DRIVE_CREDENTIALS }}" -T "${{ env.BASE_IMAGE_FILENAME }}" -sw '%{http_code}' "https://drive.offspot.it/_webdav/base/${{ env.BASE_IMAGE_FILENAME }}"

--- a/README.md
+++ b/README.md
@@ -1,29 +1,22 @@
 # base-image
 
-A Raspberry-targetting image to use as *master* for both Kiwix Offspot and OLIP through the use of [`image-creator`](https://github.com/offspot/image-creator).
+A raspiOS-like image to use as *master* for both Kiwix Offspot and OLIP through the use of [`image-creator`](https://github.com/offspot/image-creator).
 
 [![release](https://img.shields.io/github/v/tag/offspot/base-image?label=latest%20release&sort=semver)](https://drive.offspot.it/base/)
 [![CodeFactor](https://www.codefactor.io/repository/github/offspot/base-image/badge)](https://www.codefactor.io/repository/github/offspot/base-image)
 [![Build Status](https://github.com/offspot/base-image/actions/workflows/build-and-upload.yml/badge.svg?branch=main)](https://github.com/offspot/base-image/actions/workflows/build-and-upload.yml?query=branch%3Amain)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
+
 ## Scope
 
-- Based off [RaspiOS Lite](https://www.raspberrypi.com/software/).
-- Built using [`pi-gen`](https://github.com/RPi-Distro/pi-gen).
-- Using [docker-ce](https://docs.docker.com/engine/) to host applications (engine data in `/data/docker`)
-- Applications data expected on `/data`
-- Limited features to what's essential/common/stable
- - 3 Partitions: boot, root and data (`exFAT`)
- - Network configuration (dhcp on eth0, fixed on wlan0)
- - Hotspot with dnsmasq and hostAPd
- - Internet sharing from eth0 to wlan0
- - VPN client with [tinc](https://tinc-vpn.org/).
- - dev/maint non-daemon tools: vim, curl, jq, screen, git, tmux)
- - Custom/specified WiFi firmware
-- [Limited writes](https://github.com/RaspAP/raspap-tools/blob/main/raspian_min_write.sh) on root partition
-- Boot-time script to toggle features and configuration using a custom `/boot/config.json` file.
-- Captive portal *server* managed by Captive-portal APP via a socket
+This produces a raspiOS-like image that will, in a compatible device:
+
+- Setup a (configurable) WiFi Access Point
+- Setup ethernet networking (accoding to configuration)
+- Setup a docker-compose project
+
+Our **target is all Raspberry Pi 3 models and newer**. Currently: `3A+`, `3B`, `3B+`, `4B`, `400`, `Zero 2 W`.
 
 ## Usage
 
@@ -48,3 +41,22 @@ Don't validate an image without testing on actual hardware by [flashing the Imag
 ## Troubleshooting
 
 This tool mainly prepares a pi-gen custom build so checking the [troubleshooting](https://github.com/RPi-Distro/pi-gen/blob/master/README.md#troubleshooting) section there should be a first in case of any trouble. You should also be familiar with its [README](https://github.com/RPi-Distro/pi-gen/blob/master/README.md).
+
+## Using non-standard hardware
+
+We only provide support for our fixed targets list and scenarios. That said, it's a raspiOS system so you should be able to adapt it easily.
+
+- Pi Compute Module matching a supported Model with WiFi should work directly.
+- No WiFi scenario is not supported. You'll need to tweak the runtime-config script so it doesn't start `hostapd`.
+- Using additional WiFi interfaces is possible (as client or as AP). If chipset is not supported, its driver must be installed.
+- Non-arm would require tweaking the tree and the script to use regular debian sources instead of raspbian.
+- 32b ARM (Pi 0/1/2) can work. Use the `--arch=armhf` flag of the builder. In the running system, remove docker and its source-list then reinstall it from raspbian repo.
+
+```sh
+apt-get remove docker-ce docker-ce-cli containerd.io docker-compose-plugin runc
+rm /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install docker.io docker-compose
+```
+
+Please, [Open a ticket](https://github.com/offspot/base-image/issues/new) explaining what you're trying to achieve and why. We may be able to provide directions. 

--- a/builder.py
+++ b/builder.py
@@ -33,7 +33,7 @@ class Defaults:
         "2022-09-06-raspios-bullseye",
         "bd85d61c055a23a747c718741b25d3a0c0a7fbef",
     ]
-    arch: str = "armhf"
+    arch: str = "arm64"
     compress: bool = False
     dont_use_docker: bool = False
 


### PR DESCRIPTION
Following #45, this fixes #44 by cleaning out the README and clearly designating a target devices list.

With this move, it also:

- defaults to arm64 in the script.
- only uploads arm64 builds (dev ones on S3 and prod ones).
- 32b support is still present and shall remain but if you want a 32b image, you launch the script yourself.
- CI still builds 32b as well to ensure it's not broken