### PR TITLE
Internet-connectivity checker

### DIFF
--- a/tree/stage2/02-net-tweaks/01-run.sh.patch
+++ b/tree/stage2/02-net-tweaks/01-run.sh.patch
@@ -1,6 +1,6 @@
 --- tree.orig/stage2/02-net-tweaks/01-run.sh	2022-05-31 10:21:03.000000000 +0000
 +++ tree/stage2/02-net-tweaks/01-run.sh	2022-09-14 15:55:11.000000000 +0000
-@@ -35,3 +35,21 @@
+@@ -35,3 +35,26 @@
      echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
      echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
  fi
@@ -8,6 +8,10 @@
 +# unblock WiFi
 +echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
 +echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
++
++install -m 755 files/internet-check              "${ROOTFS_DIR}/usr/local/bin/"
++install -m 755 files/internet-check.service      "${ROOTFS_DIR}/etc/systemd/system/"
++install -m 755 files/internet-check.timer        "${ROOTFS_DIR}/etc/systemd/system/"
 +
 +# runtime config firewall persistence (ap)
 +mkdir -p ${ROOTFS_DIR}/etc/iptables
@@ -20,5 +24,6 @@
 +systemctl enable dhcpcd.service
 +systemctl unmask hostapd
 +systemctl disable hostapd.service dnsmasq.service iptables-restore.service
++systemctl enable internet-check.timer
 +EOF
 +

--- a/tree/stage2/02-net-tweaks/files/internet-check
+++ b/tree/stage2/02-net-tweaks/files/internet-check
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+""" tests whether connected to Internet (UDP to CloudFlare DNS) or not """
+
+import pathlib
+import socket
+import sys
+
+LOG_FILE = pathlib.Path("/var/run/internet")
+
+
+def is_connected(host="1.1.1.1"):
+    try:
+        socket.create_connection((host, 53), timeout=8)
+        return True
+    except Exception:
+        pass
+    return False
+
+
+def main():
+    connected = is_connected()
+    connected_str = "online" if connected else "offline"
+    print(connected_str)
+
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(LOG_FILE, "r") as fh:
+            if fh.read().strip() == connected_str:
+                return
+    except Exception:
+        ...
+
+    with open(LOG_FILE, "w") as fh:
+        fh.write(f"{connected_str}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tree/stage2/02-net-tweaks/files/internet-check.service
+++ b/tree/stage2/02-net-tweaks/files/internet-check.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Internet connectivity checker
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/internet-check

--- a/tree/stage2/02-net-tweaks/files/internet-check.timer
+++ b/tree/stage2/02-net-tweaks/files/internet-check.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Internet connectivity checker
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=30
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Knowing whether the system is *online* (in the sense of connected to public internet) can be useful to many applications.
One of them (where it's mandatory) being the captive portal feature. Instead of letting all those potential apps attempt to connect to internet to find out, we can provide this service via a simple text file that can be bound to containers.

`/var/run/internet` is a text file which content is one of the following:

- **`online`**
- **`offline`**

Status is extrapolated from an UDP connection to Cloudflare Public DNS (`1.1.1.1`) which is attempted every 30s via a systemd timer.

Beside this addition:

- it requests this to run before runtime-config so we are sure the file exists before creating containers