### PR TITLE
Added support for RTC hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated to pi-gen 2023-02-21-raspios-bullseye
+- Added support for hardware clock.
 
 ## [1.0.1] - 2023-03-07
 

--- a/tree/stage1/00-boot-files/files/config.txt.patch
+++ b/tree/stage1/00-boot-files/files/config.txt.patch
@@ -1,0 +1,12 @@
+*** tree.orig/stage1/00-boot-files/files/config.txt	2023-03-08 08:33:49
+--- tree/stage1/00-boot-files/files/config.txt	2023-03-08 08:36:04
+***************
+*** 1,6 ****
+--- 1,7 ----
+  # For more options and information see
+  # http://rpf.io/configtxt
+  # Some settings may impact device functionality. See link above for details
++ dtoverlay=i2c-rtc,pcf2127
+  
+  # uncomment if you get no picture on HDMI for a default "safe" mode
+  #hdmi_safe=1


### PR DESCRIPTION
Loads overlay for `i2c-rtc` device in order to support hardware clocks. `hwclock` package is already installed and running on start so there is no other configuration involved in benefiting from poweroff-resistent timekeeping.

It is users's responsibility to configure the HW clock. Can be done with standard tools on any `--privileged` container.