### PR TITLE
Using new offspot-config package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to pi-gen 2023-02-21-raspios-bullseye
+- Updated to 2023-05-03-raspios-buster
 - Added support for hardware clock.
+- Using new `offspot-config` package (which includes runtime_config)
 
 ## [1.0.1] - 2023-03-07
 

--- a/tree/stage0/00-configure-apt/files/raspi.list
+++ b/tree/stage0/00-configure-apt/files/raspi.list
@@ -1,0 +1,4 @@
+# using HTTPS URLs to workaround orange-mali's MITM broken apt mirror (dev)
+deb https://archive.raspberrypi.org/debian/ RELEASE main
+# Uncomment line below then 'apt-get update' to enable 'apt-get source'
+#deb-src https://archive.raspberrypi.org/debian/ RELEASE main

--- a/tree/stage2/07-sys-configurator/01-run.sh
+++ b/tree/stage2/07-sys-configurator/01-run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 on_chroot << EOF
-# pip3 install https://github.com/offspot/runtime-config/archive/refs/tags/v1.2.0.zip
-pip3 install offspot-runtime-config==1.2.0
+# pip3 install https://github.com/offspot/offspot-config/archive/refs/heads/main.zip
+pip3 install offspot-config==1.3.0
 EOF
 
 install -m 755 files/offspot-runtime.service       "${ROOTFS_DIR}/etc/systemd/system/"

--- a/tree/stage2/07-sys-configurator/files/offspot-runtime.service
+++ b/tree/stage2/07-sys-configurator/files/offspot-runtime.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/offspot-config-fromfile /boot/offspot.yaml
+ExecStart=/usr/local/bin/offspot-runtime-config-fromfile /boot/offspot.yaml
 RemainAfterExit=true
 StandardOutput=journal
 


### PR DESCRIPTION
runtime-config has been integrated into a new `offspot-config` package.
There is no feature change but the code base changed a bit and the scripts were renamed.